### PR TITLE
Consider noshowmode during cmdheight check

### DIFF
--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -35,9 +35,11 @@ let s:is_enabled = 0
 "}}}
 
 function! echodoc#enable() "{{{
-  if &cmdheight < 2
-    echohl Error | echomsg "[echodoc] Your cmdheight is too small."
-          \ . " You must increase 'cmdheight' value." | echohl None
+  if &showmode && &cmdheight < 2
+    " Increase the cmdheight so user can clearly see the error
+    set cmdheight=2
+    echohl Error | echomsg "[echodoc] Your cmdheight is too small. You must"
+          \ . " increase 'cmdheight' value or set noshowmode." | echohl None
   endif
 
   augroup echodoc

--- a/doc/echodoc.txt
+++ b/doc/echodoc.txt
@@ -40,15 +40,18 @@ INTRODUCTION					*echodoc-introduction*
 
 |echodoc| has the following properties which cannot be realized by ftplugin:
 	1. outputs messages from multiple plugins,
-	   (required that |cmdheight| is high enough)
+	   (required that |cmdheight| is high enough or |noshowmode|)
 	2. has a priority ranking in the search,
 	3. adds/deletes a plugin at any time,
-	4. hilights messages,
+	4. highlights messages,
 	5. uses context filetype when |context_filetype| is installed, and
-	https://github.com/Shougo/context_filetype.vim
+	   https://github.com/Shougo/context_filetype.vim
 	6. uses multiple filetypes.
 
-Note: To use echodoc, you must increase 'cmdheight' value(2 or above).
+Note: To use echodoc, you must increase 'cmdheight' value (2 or above),
+	or disable showmode with 'noshowmode' so you will be able to see
+	|echodoc|'s information clearly, without the "-- INSERT --" message
+	overwriting it.
 
 ==============================================================================
 USAGE						*echodoc-usage*
@@ -135,8 +138,14 @@ echodoc#get({name})				 *echodoc#get()*
 ==============================================================================
 EXAMPLES					*echodoc-examples*
 >
+Option 1:
 	" To use echodoc, you must increase 'cmdheight' value.
 	set cmdheight=2
+	let g:echodoc_enable_at_startup = 1
+
+Option 2:
+	" Or, you could disable showmode alltogether.
+	set noshowmode
 	let g:echodoc_enable_at_startup = 1
 >
 ==============================================================================


### PR DESCRIPTION
Instead of increasing `cmdheight`, you can set `noshowmode` and see echodoc's information.
This pull-request includes:
- Added `&showmode` condition in `cmdheight` check. `cmdheight` cannot be 0, so this is enough
- Increasing `cmdheight` with error message - otherwise user won't see the error because it disappears quickly
- Adding `noshowmode` option in documentation
- Small typo fix in *echodoc-introduction*
