### PR TITLE
Support for multiline functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 before_script:
     - git clone https://github.com/syngan/vim-vimlint /tmp/vim-vimlint
     - git clone https://github.com/ynkdir/vim-vimlparser /tmp/vim-vimlparser
+    - git clone https://github.com/thinca/vim-themis
 
 script:
     - sh /tmp/vim-vimlint/bin/vimlint.sh -l /tmp/vim-vimlint -p /tmp/vim-vimlparser -e EVL103=1 -e EVL102.l:_=1 autoload
+    - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test: vim-themis
+	vim-themis/bin/themis --reporter spec test
+
+vim-themis:
+	git clone https://github.com/thinca/vim-themis vim-themis
+
+.PHONY: test

--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -143,11 +143,6 @@ endfunction"}}}
 function! s:compare(a1, a2) abort  "{{{
   return a:a1.rank - a:a2.rank
 endfunction"}}}
-function! s:get_cur_text() abort  "{{{
-  let cur_text = matchstr(getline('.'),
-        \ printf('^.*\%%%dc%s', col('.'), (mode() ==# 'i' ? '' : '.')))
-  return cur_text
-endfunction"}}}
 function! s:context_filetype_enabled() abort  "{{{
   if !exists('s:exists_context_filetype')
     try
@@ -179,7 +174,7 @@ endfunction"}}}
 " @vimlint(EVL103, 1, a:timer)
 function! s:_on_cursor_moved(timer) abort  "{{{
   unlet! s:_timer
-  let cur_text = s:get_cur_text()
+  let cur_text = echodoc#util#get_func_text()
   let filetype = s:context_filetype_enabled() ?
         \ context_filetype#get_filetype(&filetype) : &l:filetype
 
@@ -219,7 +214,7 @@ function! s:_on_cursor_moved(timer) abort  "{{{
     endif
   endfor
 endfunction"}}}
-" @vimlint(EVL102, 1, a:timer)
+" @vimlint(EVL103, 0, a:timer)
 
 " Restore 'cpoptions' {{{
 let &cpo = s:save_cpo

--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -10,7 +10,7 @@ set cpo&vim
 " }}}
 
 " Variables  "{{{
-let s:max_parse_len = 100
+let s:max_parse_len = 1000
 let s:complete_cache = {}
 
 " Default dict. "{{{

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -1,0 +1,35 @@
+let s:assert = themis#helper('assert')
+
+function! EchodocGetFuncText() abort
+  let g:_func_name = echodoc#util#get_func_text()
+  return ''
+endfunction
+
+function! Feed(keys) abort
+  let keys = substitute(a:keys, '\([\"]\|<[^[:space:]<>]\+>\)', '\\\1', 'g')
+  unlet! g:_func_name
+  execute 'execute "normal '.keys.'"'
+endfunction
+
+function! FeedScan(keys, ...) abort
+  call Feed(a:keys.'<right>')
+  call call(s:assert.equals, [g:_func_name] + a:000)
+endfunction
+
+function! s:setup() abort
+  tabonly!
+  only!
+  enew!
+  inoremap <right> <c-r>=EchodocGetFuncText()<cr>
+endfunction
+
+function! s:teardown() abort
+  unlet! g:_func_name
+  bdelete!
+  iunmap <right>
+endfunction
+
+command! Setup silent call s:setup()
+command! Teardown silent call s:teardown()
+
+" vim: set ft=vim ts=2 sw=2 tw=78 et :

--- a/test/scan.vim
+++ b/test/scan.vim
@@ -1,0 +1,141 @@
+scriptencoding utf8
+
+let s:scan = themis#suite('Function scanning')
+
+function! s:scan.basic() abort
+  Setup
+  call FeedScan('ixxx(', 'xxx(')
+  call FeedScan('a)', '')
+  call FeedScan('i', 'xxx(')
+  call FeedScan('a<cr>', "xxx(\n")
+  call FeedScan('a)', '')
+  call FeedScan('a)', '')
+  call FeedScan('a((', '')
+  Teardown
+endfunction
+
+
+function! s:scan.single_char_func_name() abort
+  Setup
+  call FeedScan('ix()', '')
+  call FeedScan('i', 'x(')
+  Teardown
+endfunction
+
+
+function! s:scan.single_char_func_name_space() abort
+  Setup
+  call FeedScan('icall x()', '')
+  call FeedScan('i', 'x(')
+  Teardown
+endfunction
+
+
+function! s:scan.nested_func() abort
+  Setup
+  call FeedScan('ix(y(', 'y(')
+  call FeedScan('a)', 'x(y()')
+  call FeedScan('A,<cr>z', "x(y(),\nz")
+  call FeedScan('A(', 'z(')
+  Teardown
+endfunction
+
+
+function! s:scan.non_func_paren() abort
+  Setup
+  call FeedScan('ixxx((1, 2, 3),', 'xxx((1, 2, 3),')
+  call FeedScan('2hCyyy(', 'yyy(')
+  call FeedScan('A)', 'xxx((1, 2, yyy()')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx\((', '')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx ((', '')
+  Teardown
+endfunction
+
+
+function! s:scan.skip_strings() abort
+  Setup
+  call FeedScan('ixxx("yyy(",', 'xxx("yyy(",')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx(''yyy('',', 'xxx(''yyy('',')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx(`yyy(`,', 'xxx(`yyy(`,')
+  Teardown
+
+  " Ensure escaped delimiters are skipped.
+  Setup
+  call FeedScan('ixxx("yyy(\"",', 'xxx("yyy(\"",')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx(''yyy(\'''',', 'xxx(''yyy(\'''',')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx(`yyy(\``,', 'xxx(`yyy(\``,')
+  Teardown
+
+  " Ensure string skipping isn't confused by other string delimiters.
+  Setup
+  call FeedScan('ixxx("yyy(''`",', 'xxx("yyy(''`",')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx(''yyy("`'',', 'xxx(''yyy("`'',')
+  Teardown
+
+  Setup
+  call FeedScan('ixxx(`yyy(''"`,', 'xxx(`yyy(''"`,')
+  Teardown
+endfunction
+
+
+function! s:scan.multiline() abort
+  Setup
+  call FeedScan('ixxx(<cr>', "xxx(\n")
+  call FeedScan('a<cr>', '')
+  let b:echodoc_max_blank_lines = 2
+  call FeedScan('a', "xxx(\n\n")
+  Teardown
+
+  Setup
+  let b:echodoc_max_blank_lines = 0
+  call FeedScan('ixxx(<cr>', "xxx(\n")
+  call FeedScan('a<cr>', '')
+  Teardown
+
+  Setup
+  let b:echodoc_max_blank_lines = 100
+  let crs = repeat('<cr>aaa,', 49)
+  let nls = substitute(crs, '<cr>', "\n", 'g')
+  call FeedScan('ixxx('.crs, 'xxx('.nls)
+  call FeedScan('a<cr>', '')
+  Teardown
+endfunction
+
+
+function! s:scan.multibyte() abort
+  Setup
+  call FeedScan('i幸運のための河童頭の上におなら(',
+        \ '幸運のための河童頭の上におなら(')
+  call FeedScan('A(💨,(🐸 + 🐢), "✨🍀✨"',
+        \ '幸運のための河童頭の上におなら((💨,(🐸 + 🐢), "✨🍀✨"')
+  call FeedScan('A))', '')
+  Teardown
+
+  Setup
+  call FeedScan('i悪い翻訳者(<cr>', "悪い翻訳者(\n")
+  call FeedScan('a"כובע חגיגי",<cr>', "悪い翻訳者(\n\"כובע חגיגי\",\n")
+  call FeedScan('a"شعر الصدر"', "悪い翻訳者(\n\"כובע חגיגי\",\n\"شعر الصدر\"")
+  call FeedScan('a) == ("🎳', '')
+  Teardown
+endfunction


### PR DESCRIPTION
This scans backwards from the cursor to find a function.  Please test it for a few days before merging so we can be certain that the scanning is fast enough and doesn't have obscure problems.

The scanning function isn't simple, but it tries to exit the loop as early as possible.  By default if there's a 1 line gap, it stops.  The maximum scanned lines is 50 just to be safe, but shouldn't get that far in typical source code.

I raised `max_parse_len` to `1000` because I think that's reasonable for functions that have strings in them.  It should still be fast, and less noticeable when timers are used.