### PR TITLE
Fix apparent draw regression in commit 2ebcfaf81b1ead1af3418fa21136a7…

### DIFF
--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -203,7 +203,7 @@ function! s:_on_cursor_moved(timer) abort  "{{{
     endif
   endfor
 
-  redraw
+  echo ''
   for text in echodoc
     if has_key(text, 'highlight')
       execute 'echohl' text.highlight


### PR DESCRIPTION
…a302ba5802
Please see my comment in https://github.com/Shougo/echodoc.vim/issues/18

Accepting completion with `<c-y>` (either directly or through key map) did not result in function signature written to command line.

Examining recent commits showed a possible candidate for this apparent regression.

This commit reverses a recent change and fixed the problem for me.

John Heenan