### PR TITLE
Fix match for function name in word

### DIFF
--- a/autoload/echodoc/util.vim
+++ b/autoload/echodoc/util.vim
@@ -287,7 +287,7 @@ function! echodoc#util#completion_signature(completion, maxlen, filetype) abort
   endif
 
   let comp = stack[0]
-  let word = matchstr(a:completion.word, '\k\+\ze[()]*$')
+  let word = matchstr(a:completion.word, '\k\+\ze[()]*')
   if word !=# '' && comp.name !=# word
     " Completion 'word' is what actually completed, if the parsed name is
     " different, it's probably because 'info' is an abstract function


### PR DESCRIPTION
When using clangd, the word could be something like `foo(int x, int y, int c)`,  but echodoc failed to found function name this time.