### PR TITLE
Don't hardcode the namespace id for virtual text

### DIFF
--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -7,7 +7,11 @@
 " Variables
 let s:echodoc_dicts = [ echodoc#default#get() ]
 let s:is_enabled = 0
-let s:echodoc_id = 1050
+if exists('*nvim_create_namespace')
+  let s:echodoc_id = nvim_create_namespace('echodoc.vim')
+else
+  let s:echodoc_id = nvim_buf_add_highlight(0, 0, "", 0, 0, 0)
+endif
 
 let g:echodoc#type = get(g:,
       \ 'echodoc#type', 'echo')


### PR DESCRIPTION
This makes collisions with other plugins less likely.