### PR TITLE
feat: add support, display type floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,23 @@ Use a package manager and follow its instructions.
 
 Note: echodoc requires v:completed_item feature.  It is added in Vim 7.4.774.
 
-## Usage
+### Global options
 
+|Flag                               |Default            |Description                                                                                                       |
+|-----------------------------------|-------------------|------------------------------------------------------------------------------------------------------------------|
+|`g:echodoc#enable_at_startup`      |`0`                |If the value of this variable is non-zero, `echodoc` is automatically enabled at startup.                         |
+|`g:echodoc#type`                   |` "echo"`          |Where the documentation is displayed. Choose between:` "echo"`,` "signature"`, `"virtual" `or `"floating"` |
+|`g:echodoc#events`                 |`['CompleteDone']` |If the `autocmd-events` are fired, echodoc is enabled.                                                            |
+|`g:g:echodoc#highlight_identifier` |`"Identifier"`     |The highlight of identifier.                                                                                      |
+|`g:echodoc#highlight_arguments`    |`"Special"`        |The highlight of current argument.                                                                                |
+|`g:echodoc#highlight_trailing`     |`"Type"`           |The highlight of trailing.                                                                                        |
+
+## Type "echo" Usage
+
+When using
+```vim
+let g:echodoc#type = "echo" " Default value
+```
 The command line is used to display `echodoc` text.  This means that you will
 either need to `set noshowmode` or `set cmdheight=2`.  Otherwise, the `--
 INSERT --` mode text will overwrite `echodoc`'s text.
@@ -19,3 +34,36 @@ INSERT --` mode text will overwrite `echodoc`'s text.
 When you accept a completion for a function with `<c-y>`, `echodoc` will
 display the function signature in the command line and highlight the argument
 position your cursor is in.
+
+## Examples
+
+Option 1:
+```vim
+" To use echodoc, you must increase 'cmdheight' value.
+set cmdheight=2
+let g:echodoc_enable_at_startup = 1
+```
+
+Option 2:
+```vim
+" Or, you could disable showmode alltogether.
+set noshowmode
+let g:echodoc_enable_at_startup = 1
+```
+
+Option 3:
+```vim
+" Or, you could use neovim's virtual virtual text feature.
+let g:echodoc#enable_at_startup = 1
+let g:echodoc#type = 'virtual'
+```
+
+Option 4:
+```vim
+" Or, you could use neovim's floating text feature.
+let g:echodoc#enable_at_startup = 1
+let g:echodoc#type = 'floating'
+" To use a custom highlight for the float window,
+" change Pmenu to your highlight group
+highlight link EchoDocFloat Pmenu
+```

--- a/doc/echodoc.txt
+++ b/doc/echodoc.txt
@@ -1,6 +1,6 @@
 *echodoc.txt*	Print documentation in echo area
 
-Version: 1.0
+Version: 1.1
 Author : Shougo <Shougo.Matsu@gmail.com>
 License: MIT license
 
@@ -71,7 +71,7 @@ g:echodoc#events				*g:echodoc#events*
 		Default: ['CompleteDone']
 
 g:echodoc#highlight_identifier
-					*g:echodoc#highlight_identifier*
+						*g:echodoc#highlight_identifier*
 		The highlight of identifier.
 
 		Default: "Identifier"
@@ -88,13 +88,23 @@ g:echodoc#highlight_trailing
 
 		Default: "Type"
 
-g:echodoc#type				*g:echodoc#type*
+g:echodoc#type					*g:echodoc#type*
 		The documentation display type.
-		"echo": It uses the command line |:echo|.
-		"signature": It uses gonvim signature feature.
-		https://github.com/dzhou121/gonvim
-		"virtual": It uses neovim virtual text feature.
-		|nvim_buf_set_virtual_text()|
+		"echo":
+			It uses the command line |:echo|.
+		"signature":
+			It uses gonvim signature feature.
+			https://github.com/dzhou121/gonvim
+		"virtual":
+			It uses neovim virtual text feature.
+			the documentation will be placed after the buffer text.
+			|nvim_buf_set_virtual_text()|
+		"floating":
+			It uses neovim floating window feature.
+			the documentation will be placed above the cursor, as a
+			pop-up in the buffer. Has the advantage of being easier
+			to refer to. (jedi-vim like |show_call_signatures|).
+			|nvim_open_win()|
 
 		Default: "echo"
 
@@ -161,6 +171,19 @@ Option 2:
 	" Or, you could disable showmode alltogether.
 	set noshowmode
 	let g:echodoc_enable_at_startup = 1
+
+Option 3:
+	" Or, you could use neovim's virtual virtual text feature.
+	let g:echodoc#enable_at_startup = 1
+	let g:echodoc#type = 'virtual'
+
+Option 4:
+	" Or, you could use neovim's floating text feature.
+	let g:echodoc#enable_at_startup = 1
+	let g:echodoc#type = 'floating'
+	" To use a custom highlight for the float window,
+	" change Pmenu to your highlight group
+	highlight link EchoDocFloat Pmenu
 >
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:

--- a/plugin/echodoc.vim
+++ b/plugin/echodoc.vim
@@ -19,6 +19,9 @@ if g:echodoc#enable_at_startup
   augroup END
 endif
 
+" echodoc floating window highlight group
+highlight default link EchoDocFloat Pmenu
+
 command! EchoDocEnable call echodoc#enable()
 command! EchoDocDisable call echodoc#disable()
 


### PR DESCRIPTION
Only for nvim, the function signatures from completions can be displayed
in a pop-up text above the cursor.

![pop-up_demo](https://media.giphy.com/media/gjIzn6dP2QVMYjVlQq/giphy.gif)

```vim
" Config
let g:echodoc#enable_at_startup = 1
let g:echodoc#type = 'floating'
```