### PR TITLE
Add support Vim's popup window feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,13 @@ let g:echodoc#type = 'floating'
 " change Pmenu to your highlight group
 highlight link EchoDocFloat Pmenu
 ```
+
+Option 5:
+```vim
+" Or, you could use vim's popup window feature.
+let g:echodoc#enable_at_startup = 1
+let g:echodoc#type = 'popup'
+" To use a custom highlight for the popup window,
+" change Pmenu to your highlight group
+highlight link EchoDocPopup Pmenu
+```

--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -308,7 +308,7 @@ function! s:display(echodoc, filetype) abort
             \ 'highlight': 'EchoDocPopup',
             \ })
     else
-        call win_execute(s:win, 'call setbufline(winbufnr(s:win), 1, text)')
+      call win_execute(s:win, 'call setbufline(winbufnr(s:win), 1, text)')
     endif
 
     let bufnr = winbufnr(s:win)

--- a/doc/echodoc.txt
+++ b/doc/echodoc.txt
@@ -1,6 +1,6 @@
 *echodoc.txt*	Print documentation in echo area
 
-Version: 1.1
+Version: 1.2
 Author : Shougo <Shougo.Matsu@gmail.com>
 License: MIT license
 
@@ -105,6 +105,10 @@ g:echodoc#type					*g:echodoc#type*
 			pop-up in the buffer. Has the advantage of being easier
 			to refer to. (jedi-vim like |show_call_signatures|).
 			|nvim_open_win()|
+		"popup":
+			It uses vim popup window feature.
+			Works the same as "floating".
+			|popup_create()|
 
 		Default: "echo"
 
@@ -184,6 +188,14 @@ Option 4:
 	" To use a custom highlight for the float window,
 	" change Pmenu to your highlight group
 	highlight link EchoDocFloat Pmenu
+
+Option 5:
+	" Or, you could use vim's popup window feature.
+	let g:echodoc#enable_at_startup = 1
+	let g:echodoc#type = 'popup'
+	" To use a custom highlight for the popup window,
+	" change Pmenu to your highlight group
+	highlight link EchoDocPopup Pmenu
 >
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:

--- a/plugin/echodoc.vim
+++ b/plugin/echodoc.vim
@@ -22,6 +22,9 @@ endif
 " echodoc floating window highlight group
 highlight default link EchoDocFloat Pmenu
 
+" echodoc popup window highlight group
+highlight default link EchoDocPopup Pmenu
+
 command! EchoDocEnable call echodoc#enable()
 command! EchoDocDisable call echodoc#disable()
 


### PR DESCRIPTION
Implemented signature display using Vim's popup window feature.

![d9864-r5vct](https://user-images.githubusercontent.com/16581287/70368978-99866f80-18f5-11ea-8bdc-dcc30a94dc80.gif)

```vim
" Config
let g:echodoc#enable_at_startup = 1
let g:echodoc#type = 'popup'
```

This pull request related to #73