### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This PR adds ignoring generated tags. It will be useful for users who use the native package manager and update plugins through `git`.

[fzf.vim](https://github.com/junegunn/fzf.vim/blob/master/.gitignore), [neoformat](https://github.com/sbdchd/neoformat/blob/master/.gitignore), [neoterm](https://github.com/kassio/neoterm/blob/master/.gitignore), [nerdcommenter](https://github.com/preservim/nerdcommenter/blob/master/.gitignore), [nerdtree](https://github.com/preservim/nerdtree/blob/master/.gitignore) and many other plugins have the same approach.