### PR TITLE
[Fix] error in clear_documentation function, when using popup 

### DIFF
--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -202,11 +202,9 @@ function! s:clear_documentation() abort
   elseif echodoc#is_virtual()
     call nvim_buf_clear_namespace(bufnr('%'), s:echodoc_id, 0, -1)
   elseif echodoc#is_popup()
-    if s:win != v:null
-        call popup_close(s:win)
-        let s:win = v:null
-    endif
-    else
+    call popup_clear(1)
+    let s:win = v:null
+  else
     echo ''
   endif
 endfunction
@@ -299,7 +297,8 @@ function! s:display(echodoc, filetype) abort
       let s:win = v:null
     endif
 
-    if s:win == v:null
+    let bufnr = winbufnr(s:win)
+    if s:win == v:null || bufnr < 0
       let col = col('.') - ident_idx - 1
 
       let s:win = popup_create(text, {
@@ -317,6 +316,9 @@ function! s:display(echodoc, filetype) abort
 
     " highlight
     " clear
+    if bufnr < 0
+        return
+    endif
     call map(
           \ copy(prop_type_list({'bufnr': bufnr})),
           \ "prop_remove({'bufnr': bufnr, 'type': v:val, 'all': 1})",

--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -202,9 +202,11 @@ function! s:clear_documentation() abort
   elseif echodoc#is_virtual()
     call nvim_buf_clear_namespace(bufnr('%'), s:echodoc_id, 0, -1)
   elseif echodoc#is_popup()
-    call popup_close(s:win)
-    let s:win = v:null
-  else
+    if s:win != v:null
+        call popup_close(s:win)
+        let s:win = v:null
+    endif
+    else
     echo ''
   endif
 endfunction


### PR DESCRIPTION
I use echodoc and deoplete in vim. Here is my config.
```code vim
set noshowmode
let g:echodoc#enable_at_startup = 1
let g:echodoc#type = 'popup'
highlight link EchoDocFloat Pmenu
```

On press `<c-n>` to select a complete item,it report an error like this.
![image](https://user-images.githubusercontent.com/21033316/105360034-1c21d980-5c33-11eb-8e5a-87b07bd40306.png)

So,check whether s:win is null before invoke popup_close.


