### PR TITLE
Fix name for Rust completion

### DIFF
--- a/autoload/echodoc/util.vim
+++ b/autoload/echodoc/util.vim
@@ -315,8 +315,8 @@ function! echodoc#util#completion_signature(completion, maxlen, filetype) abort
 
   let comp = stack[0]
   let word = matchstr(a:completion.word, '\k\+\ze[()]*')
-  if a:filetype ==# 'go' && word !=# '' && comp.name !=# word
-    " Note: It is for Go only.
+  if index(['go', 'rust'], a:filetype) >= 0 && word !=# '' && comp.name !=# word
+    " Note: It is for Rust and Go only.
 
     " Completion 'word' is what actually completed, if the parsed name is
     " different, it's probably because 'info' is an abstract function


### PR DESCRIPTION
When using `rust-analyzer` for completion, the function is split up such that
the name is stored in word, e.g. `VimComplete.word = do_something`
however only the structure is stored in info/menu
e.g. `VimComplete.menu = fn(self, u64, ...)`. In this case we take the same
approach as go abstract functions and override the name.