### PR TITLE
Add a new option, g:echodoc#floating_config, in order to configure the floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ Displays function signatures from completions in the command line.
 
 Use a package manager and follow its instructions.
 
-Note: echodoc requires v:completed_item feature.  It is added in Vim 7.4.774.
+Note: echodoc requires v:completed_item feature. It is added in Vim 7.4.774.
 
 ### Global options
 
 |Flag                               |Default            |Description                                                                                                       |
 |-----------------------------------|-------------------|------------------------------------------------------------------------------------------------------------------|
 |`g:echodoc#enable_at_startup`      |`0`                |If the value of this variable is non-zero, `echodoc` is automatically enabled at startup.                         |
-|`g:echodoc#type`                   |` "echo"`          |Where the documentation is displayed. Choose between:` "echo"`,` "signature"`, `"virtual" `or `"floating"` |
+|`g:echodoc#type`                   |` "echo"`          |Where the documentation is displayed. Choose between:` "echo"`,` "signature"`, `"virtual" `or `"floating"`        |
 |`g:echodoc#events`                 |`['CompleteDone']` |If the `autocmd-events` are fired, echodoc is enabled.                                                            |
-|`g:echodoc#highlight_identifier` |`"Identifier"`     |The highlight of identifier.                                                                                      |
+|`g:echodoc#floating_config`        |`{}`               |The configuration for the floating window.                                                                        |
+|`g:echodoc#highlight_identifier`   |`"Identifier"`     |The highlight of identifier.                                                                                      |
 |`g:echodoc#highlight_arguments`    |`"Special"`        |The highlight of current argument.                                                                                |
 |`g:echodoc#highlight_trailing`     |`"Type"`           |The highlight of trailing.                                                                                        |
 
@@ -60,9 +61,11 @@ let g:echodoc#type = 'virtual'
 
 Option 4:
 ```vim
-" Or, you could use neovim's floating text feature.
+" Or, you could use neovim's floating window feature.
 let g:echodoc#enable_at_startup = 1
 let g:echodoc#type = 'floating'
+" You could configure the behaviour of the floating window like below:
+let g:echodoc#floating_config = {'border': 'single'}
 " To use a custom highlight for the float window,
 " change Pmenu to your highlight group
 highlight link EchoDocFloat Pmenu

--- a/autoload/echodoc.vim
+++ b/autoload/echodoc.vim
@@ -35,6 +35,9 @@ let g:echodoc#highlight_trailing = get(g:,
 let g:echodoc#events = get(g:,
       \ 'echodoc#events', ['CompleteDone', 'TextChangedP'])
 
+let g:echodoc#floating_config = get(g:,
+      \ 'echodoc#floating_config', {})
+
 function! echodoc#enable() abort
   if echodoc#is_echo() && &showmode && &cmdheight < 2
     " Increase the cmdheight so user can clearly see the error
@@ -306,13 +309,17 @@ function! s:display(echodoc, filetype, event) abort
     let window_width = strlen(hunk)
 
     call nvim_buf_set_lines(s:floating_buf, 0, -1, v:true, [hunk])
-    let opts = {
-          \ 'relative': 'cursor',
-          \ 'width': window_width,
-          \ 'height': 1,
-          \ 'col': -identifier_pos + 1,
-          \ 'row': a:echodoc[0].line - line('.'), 'anchor': 'SW'
-          \ }
+
+    let opts = g:echodoc#floating_config
+
+    call extend(opts, {
+          \   'relative': 'cursor',
+          \   'width': window_width,
+          \   'height': 1,
+          \   'col': -identifier_pos + 1,
+          \   'row': a:echodoc[0].line - line('.'), 'anchor': 'SW',
+          \ })
+
     if s:win == v:null
       let s:win = nvim_open_win(s:floating_buf, 0, opts)
 

--- a/doc/echodoc.txt
+++ b/doc/echodoc.txt
@@ -121,6 +121,14 @@ g:echodoc#type					*g:echodoc#type*
 
 		Default: "echo"
 
+g:echodoc#floating_config			*g:echodoc#type*
+		The configuration dictionary for the floating window.
+		This does matter only if you set g:echodoc#type as "floating".
+		You can use any field that is supported by nvim_open_win() as configuration,
+		except 'relative', 'width', 'height', 'col', and 'row' (these are reserved by echodoc).
+
+		Default: {}
+
 b:echodoc_enabled					*b:echodoc_enabled*
 		If it is set to non-zero, echodoc is enabled in current
 		buffer.


### PR DESCRIPTION
## What
- Add a new option `g:echodoc#floating_config` to configure the floating window.
    - As I describe in the `doc/echodoc.txt`, we can use any field that is supported by `nvim_open_win()` as configuration, except 'relative', 'width', 'height', 'col', and 'row' (these are reserved by `echodoc`).

## Motivation

In my case, I'd like to set `border` and `zindex` to the floating window created by `echodoc`.